### PR TITLE
:lipstick: Print cells in groups of neighbours with different colours

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -4,7 +4,7 @@
 typedef struct {
   unsigned char rows;
   unsigned char cols;
-  unsigned char *cells;
+  short *cells;
 } board_t;
 
 /* Copies the board */

--- a/src/copy_board.c
+++ b/src/copy_board.c
@@ -7,7 +7,7 @@
 board_t copy_board(board_t board) {
   assert(board.cells != NULL);
 
-  unsigned char *cells = malloc(board.rows * board.cols * sizeof(unsigned char));
+  short *cells = malloc(board.rows * board.cols * sizeof(short));
 
   NULL_POINTER_CHECK(cells);
 

--- a/src/init_board.c
+++ b/src/init_board.c
@@ -31,10 +31,10 @@ unsigned char get_number_from_user() {
 }
 
 /* Initialise an array of cells with random dead or alive state*/
-unsigned char *random_init_cells(unsigned char rows, unsigned char cols) {
+short *random_init_cells(unsigned char rows, unsigned char cols) {
   srand(time(0));
 
-  unsigned char *cells = malloc(rows * cols * sizeof(unsigned char));
+  short *cells = malloc(rows * cols * sizeof(short));
 
   NULL_POINTER_CHECK(cells);
 

--- a/src/print_board.c
+++ b/src/print_board.c
@@ -1,10 +1,86 @@
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "board.h"
+#include "null_pointer_check.h"
 
-void print_board(board_t board) {
+/* ANSI escape codes for coloured output */
+const char *ANSI_COLOR_RESET = "\x1b[0m";
+const char *ANSI_COLOR_RED = "\x1b[31m";
+const char *ANSI_COLOR_GREEN = "\x1b[32m";
+const char *ANSI_COLOR_YELLOW = "\x1b[33m";
+const char *ANSI_COLOR_BLUE = "\x1b[34m";
+const char *ANSI_COLOR_MAGENTA = "\x1b[35m";
+const char *ANSI_COLOR_CYAN = "\x1b[36m";
+
+/* Function to get ANSI colour code based on group number */
+const char *get_colour(short group_number) {
+  switch (group_number % 6) {
+  case 1:
+    return ANSI_COLOR_RED;
+  case 2:
+    return ANSI_COLOR_GREEN;
+  case 3:
+    return ANSI_COLOR_YELLOW;
+  case 4:
+    return ANSI_COLOR_BLUE;
+  case 5:
+    return ANSI_COLOR_MAGENTA;
+  case 0:
+    return ANSI_COLOR_CYAN;
+  default:
+    return ANSI_COLOR_RESET;
+  }
+}
+
+/* Function to perform DFS traversal */
+void dfs(unsigned char x, unsigned char y, board_t board, short *visited, short group_number) {
   assert(board.cells != NULL);
+  assert(x <= board.rows);
+  assert(y <= board.cols);
+  assert(visited != NULL);
+
+  /* Mark current cell as visited and assign group number */
+  visited[x * board.cols + y] = group_number;
+
+  /* Iterate over neighbouring cells in a 3x3 grid around the current cell (x, y) */
+  /* Loop variable type need to be able to hold 1 more value that the max of type for x and y*/
+  for (short i = x - 1; i <= x + 1; ++i) {
+    for (short j = y - 1; j <= y + 1; ++j) {
+      /* Check if the neighbor is within the bounds and is 1 and not visited */
+      if (i >= 0 && i < board.rows && j >= 0 && j < board.cols &&
+          board.cells[i * board.cols + j] == 1 && !visited[i * board.cols + j]) {
+        dfs(i, j, board, visited, group_number);
+      }
+    }
+  }
+}
+
+/* Function to find connected cells and tagging them with a group number */
+void find_groups(board_t board, short *visited) {
+  assert(board.cells != NULL);
+  assert(visited != NULL);
+
+  /* Max group number on a 255*255 board is 16384*/
+  short group_number = 0;
+
+  for (unsigned char i = 0; i < board.rows; ++i) {
+    for (unsigned char j = 0; j < board.cols; ++j) {
+      /* If current cell is not visited and has value 1, increment group number and start DFS
+       * traversal */
+      if (board.cells[i * board.cols + j] == 1 && !visited[i * board.cols + j]) {
+        ++group_number;
+        dfs(i, j, board, visited, group_number);
+      }
+    }
+  }
+}
+
+/* Print the board with colours*/
+void print_cells_with_colours(board_t board, short *visited) {
+  assert(board.cells != NULL);
+  assert(visited != NULL);
 
   char representation;
 
@@ -13,10 +89,29 @@ void print_board(board_t board) {
       if (board.cells[i * board.cols + j]) {
         representation = '*';
       } else {
+        /* NOTE: All empty cells are in group number '0' which will get assigned a colour */
+        /* but it does not matter as we are using an invisible character*/
         representation = ' ';
       }
+      printf("%s", get_colour(visited[i * board.cols + j]));
       printf(" %c ", representation);
+      printf("%s", ANSI_COLOR_RESET);
     }
     printf("\n");
   }
+}
+
+void print_board(board_t board) {
+  assert(board.cells != NULL);
+
+  /* visited will be used to store the group number */
+  /* and the fact that the cell has been visited already by the DFS */
+  short *visited = calloc(board.rows * board.cols, sizeof(short));
+  NULL_POINTER_CHECK(visited);
+
+  find_groups(board, visited);
+
+  print_cells_with_colours(board, visited);
+
+  free(visited);
 }

--- a/src/print_board.c
+++ b/src/print_board.c
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 
 #include "board.h"
-#include "null_pointer_check.h"
 
 /* ANSI escape codes for coloured output */
 const char *ANSI_COLOR_RESET = "\x1b[0m";
@@ -35,52 +34,52 @@ const char *get_colour(short group_number) {
 }
 
 /* Function to perform DFS traversal */
-void dfs(unsigned char x, unsigned char y, board_t board, short *visited, short group_number) {
+void dfs(unsigned char x, unsigned char y, board_t board, short group_number) {
   assert(board.cells != NULL);
   assert(x <= board.rows);
   assert(y <= board.cols);
-  assert(visited != NULL);
 
   /* Mark current cell as visited and assign group number */
-  visited[x * board.cols + y] = group_number;
+  board.cells[x * board.cols + y] = group_number;
 
   /* Iterate over neighbouring cells in a 3x3 grid around the current cell (x, y) */
   /* Loop variable type need to be able to hold 1 more value that the max of type for x and y*/
   for (short i = x - 1; i <= x + 1; ++i) {
     for (short j = y - 1; j <= y + 1; ++j) {
-      /* Check if the neighbor is within the bounds and is 1 and not visited */
-      if (i >= 0 && i < board.rows && j >= 0 && j < board.cols &&
-          board.cells[i * board.cols + j] == 1 && !visited[i * board.cols + j]) {
-        dfs(i, j, board, visited, group_number);
+      /* Check if the neighbour is within the bounds and is alive and not visited (i.e. equal to 1)
+       */
+      if (i >= 0 && i < board.rows && j >= 0 && j < board.cols && !(i == x && j == y) &&
+          board.cells[i * board.cols + j] == 1) {
+        dfs(i, j, board, group_number);
       }
     }
   }
 }
 
 /* Function to find connected cells and tagging them with a group number */
-void find_groups(board_t board, short *visited) {
+void find_groups(board_t board) {
   assert(board.cells != NULL);
-  assert(visited != NULL);
 
   /* Max group number on a 255*255 board is 16384*/
-  short group_number = 0;
+  /* 1 is reserved to indicate than a cell is alive and has not been visited so it cannot be used
+   * for group number */
+  short group_number = 1;
 
   for (unsigned char i = 0; i < board.rows; ++i) {
     for (unsigned char j = 0; j < board.cols; ++j) {
       /* If current cell is not visited and has value 1, increment group number and start DFS
        * traversal */
-      if (board.cells[i * board.cols + j] == 1 && !visited[i * board.cols + j]) {
+      if (board.cells[i * board.cols + j] == 1) {
         ++group_number;
-        dfs(i, j, board, visited, group_number);
+        dfs(i, j, board, group_number);
       }
     }
   }
 }
 
 /* Print the board with colours*/
-void print_cells_with_colours(board_t board, short *visited) {
+void print_cells_with_colours(board_t board) {
   assert(board.cells != NULL);
-  assert(visited != NULL);
 
   char representation;
 
@@ -93,7 +92,7 @@ void print_cells_with_colours(board_t board, short *visited) {
         /* but it does not matter as we are using an invisible character*/
         representation = ' ';
       }
-      printf("%s", get_colour(visited[i * board.cols + j]));
+      printf("%s", get_colour(board.cells[i * board.cols + j]));
       printf(" %c ", representation);
       printf("%s", ANSI_COLOR_RESET);
     }
@@ -104,14 +103,7 @@ void print_cells_with_colours(board_t board, short *visited) {
 void print_board(board_t board) {
   assert(board.cells != NULL);
 
-  /* visited will be used to store the group number */
-  /* and the fact that the cell has been visited already by the DFS */
-  short *visited = calloc(board.rows * board.cols, sizeof(short));
-  NULL_POINTER_CHECK(visited);
+  find_groups(board);
 
-  find_groups(board, visited);
-
-  print_cells_with_colours(board, visited);
-
-  free(visited);
+  print_cells_with_colours(board);
 }

--- a/src/spread_life.c
+++ b/src/spread_life.c
@@ -15,9 +15,11 @@ unsigned char count_neighbours(unsigned char x, unsigned char y, board_t board) 
   /* Loop variable type need to be able to hold 1 more value that the max of type for x and y*/
   for (short i = x - 1; i <= x + 1; ++i) {
     for (short j = y - 1; j <= y + 1; ++j) {
-      /* Check if the neighbouring cell is within the bounds of the board */
-      if (i >= 0 && i < board.rows && j >= 0 && j < board.cols && !(i == x && j == y)) {
-        neighbours += board.cells[i * board.cols + j];
+      /* Check if the neighbouring cell is within the bounds of the board and if the cell is alive
+       before considering it a neighbour */
+      if (i >= 0 && i < board.rows && j >= 0 && j < board.cols && !(i == x && j == y) &&
+          board.cells[i * board.cols + j]) {
+        ++neighbours;
       }
     }
   }

--- a/src/spread_life.c
+++ b/src/spread_life.c
@@ -39,16 +39,22 @@ void spread_life(board_t board) {
       if (old_board.cells[i * board.cols + j]) {
         /* The cell is alive */
         if (neighbours < 2 || neighbours > 3)
-        /* Cell dies if there are less than 2 or more than 3 neighbours */
+        /* Cell dies if it has less than 2 or more than 3 neighbours */
         {
           board.cells[i * board.cols + j] = 0;
+        } else {
+          /* Cell stays alive so we reset its value */
+          board.cells[i * board.cols + j] = 1;
         }
       } else {
         /* The cell is dead */
         if (neighbours == 3)
-        /* Cell comes to life if there is exactly 3 neighbours */
+        /* Cell comes to life if it has exactly 3 neighbours */
         {
           board.cells[i * board.cols + j] = 1;
+        } else {
+          /* Cell stays dead so we reset its value */
+          board.cells[i * board.cols + j] = 0;
         }
       }
     }


### PR DESCRIPTION
I purposefully chose to create a dedicated array for the groups and visited status.

Now, we can modify things and use a struct for the cells so that they store a value and a group instead of just there value.
This visited status would have to be reset at the time of printing but it would avoid multiple calls to dynamic allocation. 
Despite needing an extra iteration over an array with the size of the board, this reset may actually be faster if I understand things correctly regarding how "slow" dynamic memory allocation is.

Pushing this further, we can also use the cell value itself to track life, group numbers and visited status all at once by reserving 0 and 1 to life and 2+ for alive group numbers. 
This way, we would not even need the visited array entirely.

I fear it may make everything less readable however and that is why I went for a less optimised way for now. It is also a good starting point for any remarks regarding this colouring strategy.  

What is your take on this?
As usual, I welcome any suggestions you may have, including other ways to use fancy colours in the prints.